### PR TITLE
Add input blur logging with screenshot

### DIFF
--- a/content.js
+++ b/content.js
@@ -21,6 +21,34 @@ document.addEventListener("keydown", (e) => {
   console.log("Interação registrada:", info);
 });
 
+// Registra o valor informado em inputs e tira screenshot ao perder o foco
+document.addEventListener(
+  "blur",
+  (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
+      const info = {
+        tipo: "input",
+        valor: e.target.value,
+        quando: new Date().toISOString(),
+      };
+      interacoes.push(info);
+      console.log("Interação registrada:", info);
+
+      chrome.runtime.sendMessage("capturar", (res) => {
+        if (res && res.imagem) {
+          interacoes.push({
+            tipo: "screenshot",
+            imagem: res.imagem,
+            quando: new Date().toISOString(),
+          });
+          console.log("Screenshot capturada.");
+        }
+      });
+    }
+  },
+  true
+);
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg === "getInteracoes") {
     sendResponse(interacoes);


### PR DESCRIPTION
## Summary
- log value typed in inputs when they lose focus
- trigger a screenshot when that blur event occurs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685711c8f368832f9f217d1a007fc751