### PR TITLE
Add capture control buttons and saving

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,42 +1,43 @@
 let interacoes = [];
+let capturando = false;
+
+function registrar(info) {
+  if (!capturando) return;
+  interacoes.push(info);
+  console.log("Interação registrada:", info);
+}
 
 document.addEventListener("click", (e) => {
-  const info = {
+  registrar({
     tipo: "clique",
     tag: e.target.tagName,
     texto: e.target.innerText,
-    quando: new Date().toISOString()
-  };
-  interacoes.push(info);
-  console.log("Interação registrada:", info);
+    quando: new Date().toISOString(),
+  });
 });
 
 document.addEventListener("keydown", (e) => {
-  const info = {
+  registrar({
     tipo: "tecla",
     tecla: e.key,
-    quando: new Date().toISOString()
-  };
-  interacoes.push(info);
-  console.log("Interação registrada:", info);
+    quando: new Date().toISOString(),
+  });
 });
 
 // Registra o valor informado em inputs e tira screenshot ao perder o foco
 document.addEventListener(
   "blur",
   (e) => {
-    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") {
-      const info = {
+    if ((e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") && capturando) {
+      registrar({
         tipo: "input",
         valor: e.target.value,
         quando: new Date().toISOString(),
-      };
-      interacoes.push(info);
-      console.log("Interação registrada:", info);
+      });
 
       chrome.runtime.sendMessage("capturar", (res) => {
         if (res && res.imagem) {
-          interacoes.push({
+          registrar({
             tipo: "screenshot",
             imagem: res.imagem,
             quando: new Date().toISOString(),
@@ -52,5 +53,12 @@ document.addEventListener(
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg === "getInteracoes") {
     sendResponse(interacoes);
+  } else if (msg === "toggleCaptura") {
+    capturando = !capturando;
+    sendResponse({ capturando });
+  } else if (msg === "finalizar") {
+    capturando = false;
+    sendResponse(interacoes);
+    interacoes = [];
   }
 });

--- a/popup.html
+++ b/popup.html
@@ -5,6 +5,8 @@
   <title>Interações</title>
 </head>
 <body>
+  <button id="toggle">Iniciar Captura</button>
+  <button id="finalizar">Finalizar e Salvar</button>
   <button id="ver">Ver Interações</button>
   <button id="print">Capturar Tela</button>
   <div id="resultado"></div>

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,34 @@
+let estadoCaptura = false;
+
+document.getElementById("toggle").addEventListener("click", () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    chrome.tabs.sendMessage(tab.id, "toggleCaptura", (res) => {
+      estadoCaptura = res.capturando;
+      document.getElementById("toggle").textContent = estadoCaptura
+        ? "Pausar Captura"
+        : "Iniciar Captura";
+    });
+  });
+});
+
+document.getElementById("finalizar").addEventListener("click", () => {
+  chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
+    chrome.tabs.sendMessage(tab.id, "finalizar", (dados) => {
+      const blob = new Blob([JSON.stringify(dados, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "interacoes.json";
+      a.click();
+      URL.revokeObjectURL(url);
+      estadoCaptura = false;
+      document.getElementById("toggle").textContent = "Iniciar Captura";
+    });
+  });
+});
+
 document.getElementById("ver").addEventListener("click", () => {
   chrome.tabs.query({ active: true, currentWindow: true }, ([tab]) => {
     chrome.tabs.sendMessage(tab.id, "getInteracoes", (resposta) => {

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ GuiaClick é uma extensão para o Google Chrome que registra interações do usu
 
 - Registra cliques e teclas.
 - Captura screenshots da aba ativa.
+- Permite iniciar e pausar a captura.
+- Finaliza a sessão e salva um arquivo com os dados coletados.
 - Exibe os dados registrados em um painel popup.
 - Gera uma base para criação de tutoriais.
 
@@ -22,6 +24,8 @@ GuiaClick é uma extensão para o Google Chrome que registra interações do usu
 1. Acesse qualquer página da web.
 2. Clique no ícone da extensão.
 3. Use os botões:
+   - **Iniciar/Pausar Captura**: alterna o registro de interações.
+   - **Finalizar e Salvar**: encerra a sessão e baixa um arquivo JSON com os dados.
    - **Ver Interações**: lista os cliques e teclas capturados.
    - **Capturar Tela**: tira um print da aba atual e exibe no popup.
 


### PR DESCRIPTION
## Summary
- add capture flag and handlers in content script
- add start/pause and finalize buttons to popup
- implement toggle and finalize logic in popup JS
- document new buttons in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685712876b24832f9e98037cca85b774