### PR TITLE
Fix popup reset

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -36,6 +36,8 @@ document.getElementById("finalizar").addEventListener("click", () => {
       URL.revokeObjectURL(url);
       estadoCaptura = false;
       document.getElementById("toggle").textContent = "Iniciar Captura";
+      // limpa resultados do popup para nova sessao
+      document.getElementById("resultado").innerHTML = "";
     });
   });
 });

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ GuiaClick é uma extensão para o Google Chrome que registra interações do usu
 
 - A captura de tela recorta a região do elemento clicado quando possível.
 - Os dados são mantidos apenas em memória enquanto a página estiver aberta.
+- O arquivo HTML gerado ao finalizar inclui todas as interações e screenshots.
+- Após o salvamento a extensão fica pronta para iniciar uma nova captura.
 
 ## Licença
 


### PR DESCRIPTION
## Summary
- clear popup info after saving the HTML to start a new session
- document that the saved HTML contains all interactions and screenshots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571960d1e8832f8503342584fc3484